### PR TITLE
Replace visdom with wandb logging

### DIFF
--- a/config/train_config.yaml
+++ b/config/train_config.yaml
@@ -43,3 +43,5 @@ use_kl: false
 predict_xstart: true
 rescale_timesteps: false
 rescale_learned_sigmas: false
+wandb_project: MedSeg
+wandb_run_name: training

--- a/guided_diffusion/train_util.py
+++ b/guided_diffusion/train_util.py
@@ -40,6 +40,7 @@ class TrainLoop:
         schedule_sampler=None,
         weight_decay=0.0,
         lr_anneal_steps=0,
+        use_wandb=False,
     ):
         self.model = model
         self.dataloader = dataloader
@@ -60,6 +61,7 @@ class TrainLoop:
         self.schedule_sampler = schedule_sampler or UniformSampler(diffusion)
         self.weight_decay = weight_decay
         self.lr_anneal_steps = lr_anneal_steps
+        self.use_wandb = use_wandb
 
         self.step = 0
         self.resume_step = 0
@@ -142,7 +144,10 @@ class TrainLoop:
             self.run_step(batch, cond)
             i += 1
             if self.step % self.log_interval == 0:
-                logger.dumpkvs()
+                metrics = logger.dumpkvs()
+                if self.use_wandb:
+                    import wandb
+                    wandb.log(metrics, step=self.step + self.resume_step)
             if self.step % self.save_interval == 0:
                 self.save()
                 if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:

--- a/scripts/segmentation_train.py
+++ b/scripts/segmentation_train.py
@@ -9,7 +9,7 @@ sys.path.append("./")
 
 import torch as th
 import torchvision.transforms as transforms
-from visdom import Visdom
+import wandb
 from guided_diffusion import dist_util, logger
 from guided_diffusion.resample import create_named_schedule_sampler
 from guided_diffusion.bratsloader import BRATSDataset, BRATSDataset3D
@@ -22,8 +22,6 @@ from guided_diffusion.script_util import (
 )
 from guided_diffusion.train_util import TrainLoop
 
-viz = Visdom(port=8850, use_incoming_socket=False)
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', type=str, default='config/train_config.yaml', help='Path to training config YAML')
@@ -35,6 +33,8 @@ def main():
     defaults = create_defaults()
     defaults.update(cfg)
     args = Namespace(**defaults)
+
+    wandb.init(project=args.wandb_project, name=args.wandb_run_name, config=defaults)
 
     accelerator = Accelerator(fp16=args.use_fp16)
 
@@ -73,6 +73,7 @@ def main():
     )
 
     model.to(accelerator.device)
+    wandb.watch(model, log="all")
 
     schedule_sampler = create_named_schedule_sampler(
         args.schedule_sampler, diffusion, maxt=args.diffusion_steps
@@ -97,6 +98,7 @@ def main():
         schedule_sampler=schedule_sampler,
         weight_decay=args.weight_decay,
         lr_anneal_steps=args.lr_anneal_steps,
+        use_wandb=True,
     ).run_loop()
 
 def create_defaults():
@@ -117,7 +119,9 @@ def create_defaults():
         fp16_scale_growth=1e-3,
         gpu_dev="0",
         multi_gpu="0,1",
-        out_dir='./results/'
+        out_dir='./results/',
+        wandb_project='MedSeg',
+        wandb_run_name='training'
     )
     defaults.update(model_and_diffusion_defaults())
     return defaults


### PR DESCRIPTION
## Summary
- remove unused visdom dependency
- add wandb for experiment tracking
- log training metrics to wandb
- expose wandb settings in config

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686393077fb48326b2b7402307932435