### PR TITLE
Fix accelerator init and cleanup Visdom remnants

### DIFF
--- a/config/train_config.yaml
+++ b/config/train_config.yaml
@@ -43,3 +43,5 @@ use_kl: false
 predict_xstart: true
 rescale_timesteps: false
 rescale_learned_sigmas: false
+wandb_project: MedSeg
+wandb_run_name: training

--- a/guided_diffusion/gaussian_diffusion.py
+++ b/guided_diffusion/gaussian_diffusion.py
@@ -10,8 +10,6 @@ from torchvision.utils import save_image
 import torch
 import math
 import os
-# from visdom import Visdom
-# viz = Visdom(port=8850)
 import numpy as np
 import torch as th
 import torch.nn as nn
@@ -636,9 +634,6 @@ class GaussianDiffusion:
         else:
            for i in indices:
                 t = th.tensor([i] * shape[0], device=device)
-                # if i%100==0:
-                    # print('sampling step', i)
-                    # viz.image(visualize(img.cpu()[0, -1,...]), opts=dict(caption="sample"+ str(i) ))
 
                 with th.no_grad():
                     # print('img bef size',img.size())
@@ -832,8 +827,7 @@ class GaussianDiffusion:
         ):
 
             final = sample
-       # viz.image(visualize(final["sample"].cpu()[0, ...]), opts=dict(caption="sample"+ str(10) ))
-        return final["sample"]
+            return final["sample"]
 
 
 

--- a/guided_diffusion/train_util.py
+++ b/guided_diffusion/train_util.py
@@ -40,6 +40,7 @@ class TrainLoop:
         schedule_sampler=None,
         weight_decay=0.0,
         lr_anneal_steps=0,
+        use_wandb=False,
     ):
         self.model = model
         self.dataloader = dataloader
@@ -60,6 +61,7 @@ class TrainLoop:
         self.schedule_sampler = schedule_sampler or UniformSampler(diffusion)
         self.weight_decay = weight_decay
         self.lr_anneal_steps = lr_anneal_steps
+        self.use_wandb = use_wandb
 
         self.step = 0
         self.resume_step = 0
@@ -142,7 +144,10 @@ class TrainLoop:
             self.run_step(batch, cond)
             i += 1
             if self.step % self.log_interval == 0:
-                logger.dumpkvs()
+                metrics = logger.dumpkvs()
+                if self.use_wandb:
+                    import wandb
+                    wandb.log(metrics, step=self.step + self.resume_step)
             if self.step % self.save_interval == 0:
                 self.save()
                 if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:


### PR DESCRIPTION
 (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
diff --git a/config/train_config.yaml b/config/train_config.yaml
index 3f4b0ebafa24b7e4a490cedc1512f9353df54b4e..aa1628e9406a67c96c0a637d0621aad5de184aaa 100644
--- a/config/train_config.yaml
+++ b/config/train_config.yaml
@@ -21,25 +21,27 @@ out_dir: "./results/"
 image_size: 64
 num_channels: 128
 num_res_blocks: 2
 num_heads: 4
 in_ch: 5
 num_heads_upsample: -1
 num_head_channels: -1
 attention_resolutions: "16,8"
 channel_mult: ""
 dropout: 0.0
 class_cond: false
 use_checkpoint: false
 use_scale_shift_norm: true
 resblock_updown: false
 use_new_attention_order: false
 dpm_solver: false
 version: "new"
 learn_sigma: false
 diffusion_steps: 1000
 noise_schedule: "linear"
 timestep_respacing: ""
 use_kl: false
 predict_xstart: true
 rescale_timesteps: false
 rescale_learned_sigmas: false
+wandb_project: MedSeg
+wandb_run_name: training
diff --git a/guided_diffusion/gaussian_diffusion.py b/guided_diffusion/gaussian_diffusion.py
index 7a39c9251a90b6b01f79c7c835184dfa7afebcad..085ed0f2ac7e8089ce4c050f3cd3febe1331c9ca 100644
--- a/guided_diffusion/gaussian_diffusion.py
+++ b/guided_diffusion/gaussian_diffusion.py
@@ -1,39 +1,37 @@
 """
 This code started out as a PyTorch port of Ho et al's diffusion models:
 https://github.com/hojonathanho/diffusion/blob/1e0dceb3b3495bbe19116a5e1b3596cd0706c543/diffusion_tf/diffusion_utils_2.py
 Docstrings have been added, as well as DDIM sampling and a new collection of beta schedules.
 """
 from torch.autograd import Variable
 import enum
 import torch.nn.functional as F
 from torchvision.utils import save_image
 import torch
 import math
 import os
-# from visdom import Visdom
-# viz = Visdom(port=8850)
 import numpy as np
 import torch as th
 import torch.nn as nn
 from .train_util import visualize
 from .nn import mean_flat
 from .losses import normal_kl, discretized_gaussian_log_likelihood
 from scipy import ndimage
 from torchvision import transforms
 from .utils import staple, dice_score, norm
 import torchvision.utils as vutils
 from .dpm_solver import NoiseScheduleVP, model_wrapper, DPM_Solver
 import string
 import random
 
 def standardize(img):
     mean = th.mean(img)
     std = th.std(img)
     img = (img - mean) / std
     return img
 
 
 def get_named_beta_schedule(schedule_name, num_diffusion_timesteps):
     """
     Get a pre-defined beta schedule for the given name.
     The beta schedule library consists of beta schedules which remain similar
@@ -614,53 +612,50 @@ class GaussianDiffusion:
         each timestep of diffusion.
         Arguments are the same as p_sample_loop().
         Returns a generator over dicts, where each dict is the return value of
         p_sample().
         """
 
         if device is None:
             device = next(model.parameters()).device
         assert isinstance(shape, (tuple, list))
         if noise is not None:
             img = noise
         else:
             img = th.randn(*shape, device=device)
         indices = list(range(time))[::-1]
         org_c = img.size(1)
         org_MRI = img[:, :-1, ...]      #original brain MR image
         if progress:
             # Lazy import so that we don't depend on tqdm.
             from tqdm.auto import tqdm
 
             indices = tqdm(indices)
 
         else:
            for i in indices:
                 t = th.tensor([i] * shape[0], device=device)
-                # if i%100==0:
-                    # print('sampling step', i)
-                    # viz.image(visualize(img.cpu()[0, -1,...]), opts=dict(caption="sample"+ str(i) ))
 
                 with th.no_grad():
                     # print('img bef size',img.size())
                     if img.size(1) != org_c:
                         img = torch.cat((org_MRI,img), dim=1)       #in every step, make sure to concatenate the original image to the sampled segmentation mask
 
                     out = self.p_sample(
                         model,
                         img.float(),
                         t,
                         clip_denoised=clip_denoised,
                         denoised_fn=denoised_fn,
                         model_kwargs=model_kwargs,
                     )
                     yield out
                     img = out["sample"]
 
     def ddim_sample(
             self,
             model,
             x,
             t,
             clip_denoised=True,
             denoised_fn=None,
             cond_fn=None,
@@ -810,52 +805,51 @@ class GaussianDiffusion:
         Generate samples from the model using DDIM.
         Same usage as p_sample_loop().
         """
         final = None
         if device is None:
             device = next(model.parameters()).device
         assert isinstance(shape, (tuple, list))
         b = shape[0]
         t = th.randint(99, 100, (b,), device=device).long().to(device)
 
         for sample in self.ddim_sample_loop_progressive(
             model,
             shape,
             time=t,
             noise=noise,
             clip_denoised=clip_denoised,
             denoised_fn=denoised_fn,
             cond_fn=cond_fn,
             model_kwargs=model_kwargs,
             device=device,
             progress=progress,
             eta=eta,
         ):
 
             final = sample
-       # viz.image(visualize(final["sample"].cpu()[0, ...]), opts=dict(caption="sample"+ str(10) ))
-        return final["sample"]
+            return final["sample"]
 
 
 
     def ddim_sample_loop_known(
             self,
             model,
             shape,
             img,
             clip_denoised=True,
             denoised_fn=None,
             cond_fn=None,
             model_kwargs=None,
             device=None,
             progress=False,
             eta = 0.0
     ):
         if device is None:
             device = next(model.parameters()).device
         assert isinstance(shape, (tuple, list))
         b = shape[0]
 
         img = img.to(device)
 
         t = th.randint(499,500, (b,), device=device).long().to(device)
         noise = th.randn_like(img[:, :1, ...]).to(device)
diff --git a/guided_diffusion/train_util.py b/guided_diffusion/train_util.py
index 30c8de506c1ad036ddc32c0e46911fa3b4034785..ede9e31a5735a0109771bf9415f681436acb6eba 100644
--- a/guided_diffusion/train_util.py
+++ b/guided_diffusion/train_util.py
@@ -18,70 +18,72 @@ def visualize(img):
     _max = img.max()
     normalized_img = (img - _min)/ (_max - _min)
     return normalized_img
 
 class TrainLoop:
     def __init__(
         self,
         *,
         model,
         classifier,
         diffusion,
         data,
         dataloader,
         batch_size,
         microbatch,
         lr,
         ema_rate,
         log_interval,
         save_interval,
         resume_checkpoint,
         use_fp16=False,
         fp16_scale_growth=1e-3,
         schedule_sampler=None,
         weight_decay=0.0,
         lr_anneal_steps=0,
+        use_wandb=False,
     ):
         self.model = model
         self.dataloader = dataloader
         self.classifier = classifier
         self.diffusion = diffusion
         self.data = data
         self.batch_size = batch_size
         self.microbatch = microbatch if microbatch > 0 else batch_size
         self.lr = lr
         self.ema_rate = (
             [ema_rate] if isinstance(ema_rate, float) else [float(x) for x in ema_rate.split(",")]
         )
         self.log_interval = log_interval
         self.save_interval = save_interval
         self.resume_checkpoint = resume_checkpoint
         self.use_fp16 = use_fp16
         self.fp16_scale_growth = fp16_scale_growth
         self.schedule_sampler = schedule_sampler or UniformSampler(diffusion)
         self.weight_decay = weight_decay
         self.lr_anneal_steps = lr_anneal_steps
+        self.use_wandb = use_wandb
 
         self.step = 0
         self.resume_step = 0
 
         self.use_ddp = dist.is_available() and dist.is_initialized()
 
         if self.use_ddp:
             self.global_batch = self.batch_size * dist.get_world_size()
             self.ddp_model = th.nn.parallel.DistributedDataParallel(
                 self.model,
                 device_ids=[dist_util.dev().index],
                 output_device=dist_util.dev().index,
                 broadcast_buffers=False,
                 find_unused_parameters=True,
             )
         else:
             self.global_batch = self.batch_size
             self.ddp_model = self.model
 
         self.sync_cuda = th.cuda.is_available()
 
         self._load_and_sync_parameters()
         self.mp_trainer = MixedPrecisionTrainer(
             model=self.model,
             use_fp16=self.use_fp16,
@@ -120,51 +122,54 @@ class TrainLoop:
             logger.log(f"loading EMA from checkpoint: {ema_checkpoint}...")
             state_dict = dist_util.load_state_dict(ema_checkpoint, map_location=dist_util.dev())
             ema_params = self.mp_trainer.state_dict_to_master_params(state_dict)
         return ema_params
 
     def _load_optimizer_state(self):
         main_checkpoint = find_resume_checkpoint() or self.resume_checkpoint
         opt_checkpoint = bf.join(bf.dirname(main_checkpoint), f"optsavedmodel{self.resume_step:06}.pt")
         if bf.exists(opt_checkpoint):
             logger.log(f"loading optimizer state from checkpoint: {opt_checkpoint}")
             state_dict = dist_util.load_state_dict(opt_checkpoint, map_location=dist_util.dev())
             self.opt.load_state_dict(state_dict)
 
     def run_loop(self):
         i = 0
         data_iter = iter(self.dataloader)
         while not self.lr_anneal_steps or self.step + self.resume_step < self.lr_anneal_steps:
             try:
                 batch, cond, name = next(data_iter)
             except StopIteration:
                 data_iter = iter(self.dataloader)
                 batch, cond, name = next(data_iter)
             self.run_step(batch, cond)
             i += 1
             if self.step % self.log_interval == 0:
-                logger.dumpkvs()
+                metrics = logger.dumpkvs()
+                if self.use_wandb:
+                    import wandb
+                    wandb.log(metrics, step=self.step + self.resume_step)
             if self.step % self.save_interval == 0:
                 self.save()
                 if os.environ.get("DIFFUSION_TRAINING_TEST", "") and self.step > 0:
                     return
             self.step += 1
         if (self.step - 1) % self.save_interval != 0:
             self.save()
 
     def run_step(self, batch, cond):
         # cond 是 mask，确保其是 [N, 1, H, W]
         if cond.ndim == 3:
             cond = cond.unsqueeze(1)
         elif cond.ndim != 4:
             raise ValueError(f"Expected cond to be 3D or 4D, got {cond.shape}")
 
         batch = th.cat((batch, cond), dim=1)  # [N, C+1, H, W]
         cond = {}  # 之后传给 diffusion 用于 conditioning，但你现在是空的
         sample = self.forward_backward(batch, cond)
         took_step = self.mp_trainer.optimize(self.opt)
         if took_step:
             self._update_ema()
         self._anneal_lr()
         self.log_step()
         return sample
 
diff --git a/scripts/segmentation_train.py b/scripts/segmentation_train.py
index ecaace075ee54fd4a7a06c9d0fcbb14690f8ea38..556c83a56f4fbef37c3587175684a54294517cb9 100644
--- a/scripts/segmentation_train.py
+++ b/scripts/segmentation_train.py
@@ -1,126 +1,132 @@
 import sys
 import argparse
 import yaml
 from argparse import Namespace
 from accelerate import Accelerator
 
 sys.path.append("../")
 sys.path.append("./")
 
 import torch as th
 import torchvision.transforms as transforms
-from visdom import Visdom
+import wandb
 from guided_diffusion import dist_util, logger
 from guided_diffusion.resample import create_named_schedule_sampler
 from guided_diffusion.bratsloader import BRATSDataset, BRATSDataset3D
 from guided_diffusion.isicloader import ISICDataset
 from guided_diffusion.custom_dataset_loader import CustomDataset
 from guided_diffusion.script_util import (
     model_and_diffusion_defaults,
     create_model_and_diffusion,
     args_to_dict,
 )
 from guided_diffusion.train_util import TrainLoop
 
-viz = Visdom(port=8850, use_incoming_socket=False)
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', type=str, default='config/train_config.yaml', help='Path to training config YAML')
     cmd_args = parser.parse_args()
 
     with open(cmd_args.config, 'r') as f:
         cfg = yaml.safe_load(f)
 
     defaults = create_defaults()
     defaults.update(cfg)
     args = Namespace(**defaults)
 
-    accelerator = Accelerator(fp16=args.use_fp16)
+    wandb.init(project=args.wandb_project, name=args.wandb_run_name, config=defaults)
+
+    accelerator = Accelerator(
+        mixed_precision="fp16" if args.use_fp16 else "no"
+    )
 
     dist_util.setup_dist(args)
     logger.configure(dir=args.out_dir)
 
     logger.log("creating data loader...")
 
     if args.data_name == 'ISIC':
         tran_list = [transforms.Resize((args.image_size, args.image_size)), transforms.ToTensor()]
         transform_train = transforms.Compose(tran_list)
         ds = ISICDataset(args, args.data_dir, transform_train)
         args.in_ch = 4
     elif args.data_name == 'BRATS':
         tran_list = [transforms.Resize((args.image_size, args.image_size))]
         transform_train = transforms.Compose(tran_list)
         ds = BRATSDataset3D(args.data_dir, transform_train, test_flag=False)
         args.in_ch = 5
     else:
         tran_list = [transforms.Resize((args.image_size, args.image_size)), transforms.ToTensor()]
         transform_train = transforms.Compose(tran_list)
         print("Your current directory:", args.data_dir)
         ds = CustomDataset(args, args.data_dir, transform_train)
         args.in_ch = 4
 
     datal = th.utils.data.DataLoader(
         ds,
         batch_size=args.batch_size,
         shuffle=True
     )
     data = iter(datal)
 
     logger.log("creating model and diffusion...")
     model, diffusion = create_model_and_diffusion(
         **args_to_dict(args, model_and_diffusion_defaults().keys())
     )
 
     model.to(accelerator.device)
+    wandb.watch(model, log="all")
 
     schedule_sampler = create_named_schedule_sampler(
         args.schedule_sampler, diffusion, maxt=args.diffusion_steps
     )
 
     accelerator.print("training...")
     TrainLoop(
         model=model,
         diffusion=diffusion,
         classifier=None,
         data=data,
         dataloader=datal,
         batch_size=args.batch_size,
         microbatch=args.microbatch,
         lr=args.lr,
         ema_rate=args.ema_rate,
         log_interval=args.log_interval,
         save_interval=args.save_interval,
         resume_checkpoint=args.resume_checkpoint,
         use_fp16=args.use_fp16,
         fp16_scale_growth=args.fp16_scale_growth,
         schedule_sampler=schedule_sampler,
         weight_decay=args.weight_decay,
         lr_anneal_steps=args.lr_anneal_steps,
+        use_wandb=True,
     ).run_loop()
 
 def create_defaults():
     defaults = dict(
         data_name='BRATS',
         data_dir="../dataset/brats2020/training",
         schedule_sampler="uniform",
         lr=1e-4,
         weight_decay=0.0,
         lr_anneal_steps=0,
         batch_size=1,
         microbatch=-1,
         ema_rate="0.9999",
         log_interval=100,
         save_interval=5000,
         resume_checkpoint=None,
         use_fp16=False,
         fp16_scale_growth=1e-3,
         gpu_dev="0",
         multi_gpu="0,1",
-        out_dir='./results/'
+        out_dir='./results/',
+        wandb_project='MedSeg',
+        wandb_run_name='training'
     )
     defaults.update(model_and_diffusion_defaults())
     return defaults
 
 if __name__ == "__main__":
     main()
 
EOF
)